### PR TITLE
Add Notification Settings Toggle with Firestore Sync and Theme-Compatible UI

### DIFF
--- a/lib/providers/notification_settings_provider.dart
+++ b/lib/providers/notification_settings_provider.dart
@@ -1,0 +1,4 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Provider to track whether notifications are enabled.
+final notificationEnabledProvider = StateProvider<bool>((ref) => true);

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -7,6 +7,7 @@ import '../providers/documents_provider.dart';
 import '../widgets/document_card.dart';
 import '../services/notification_service.dart';
 import '../services/user_service.dart';
+import '../providers/notification_settings_provider.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -22,7 +23,10 @@ class _HomePageState extends ConsumerState<HomePage> {
   void initState() {
     super.initState();
     _searchController.addListener(_onSearchChanged);
-    NotificationService.checkAndNotifyExpiringDocuments();
+    final enabled = ref.read(notificationEnabledProvider);
+    if (enabled) {
+      NotificationService.checkAndNotifyExpiringDocuments();
+    }
     _setupNotifications(); // Call the notification setup here.
   }
 

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/theme_settings_provider.dart';
+import '../providers/notification_settings_provider.dart';
+import '../services/user_service.dart';
 import 'package:go_router/go_router.dart';
 
 class SettingsPage extends ConsumerWidget {
@@ -10,7 +12,8 @@ class SettingsPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final themeSettings = ref.watch(themeSettingsProvider);
     final themeNotifier = ref.read(themeSettingsProvider.notifier);
-    
+    final notificationsEnabled = ref.watch(notificationEnabledProvider);
+    final notificationsNotifier = ref.read(notificationEnabledProvider.notifier);
 
     return Scaffold(
       appBar: AppBar(
@@ -25,7 +28,7 @@ class SettingsPage extends ConsumerWidget {
       body: ListView(
         padding: const EdgeInsets.all(16.0),
         children: [
-          // Theme Mode Toggle (Modified for default light theme)
+          // Theme Mode Toggle
           Card(
             margin: const EdgeInsets.only(bottom: 16.0),
             elevation: 2,
@@ -51,6 +54,8 @@ class SettingsPage extends ConsumerWidget {
                       );
                     },
                     activeColor: Theme.of(context).colorScheme.primary,
+                    inactiveThumbColor: Colors.grey.shade400,
+                    inactiveTrackColor: Colors.grey.shade300,
                   ),
                   const SizedBox(height: 8),
                   Text(
@@ -89,10 +94,7 @@ class SettingsPage extends ConsumerWidget {
                       themeNotifier.setBrightness(value);
                     },
                     activeColor: Theme.of(context).colorScheme.primary,
-                    // FIX: Replaced withOpacity with withAlpha for better precision
-                    inactiveColor: Theme.of(
-                      context,
-                    ).colorScheme.primary.withAlpha((255 * 0.3).round()),
+                    inactiveColor: Theme.of(context).colorScheme.primary.withAlpha((255 * 0.3).round()),
                   ),
                   Center(
                     child: Text(
@@ -105,6 +107,7 @@ class SettingsPage extends ConsumerWidget {
             ),
           ),
 
+          // Font Size Controls
           Card(
             margin: const EdgeInsets.only(bottom: 16.0),
             elevation: 2,
@@ -151,27 +154,45 @@ class SettingsPage extends ConsumerWidget {
             ),
           ),
 
+          // Notification Toggle with Firestore sync
           Card(
             margin: const EdgeInsets.only(bottom: 16.0),
             elevation: 2,
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(12),
             ),
-            child: ListTile(
-              leading: const Icon(Icons.notifications),
-              title: const Text('Notification Settings'),
-              trailing: Switch(
-                value: true,
-                onChanged: (bool value) {},
-                activeColor: Theme.of(context).colorScheme.primary,
-              ),
-              onTap: () {
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(
-                    content: Text('Go to detailed notification settings'),
+            child: Padding(
+              padding: const EdgeInsets.all(16.0),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  const Row(
+                    children: [
+                      Icon(Icons.notifications),
+                      SizedBox(width: 16),
+                      Text('Notification Settings'),
+                    ],
                   ),
-                );
-              },
+                  Switch(
+                    value: notificationsEnabled,
+                    onChanged: (bool value) async {
+                      notificationsNotifier.state = value;
+                      await UserService.updateNotificationPreference(value);
+
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text(value
+                              ? 'Notifications enabled'
+                              : 'Notifications disabled'),
+                        ),
+                      );
+                    },
+                    activeColor: Theme.of(context).colorScheme.primary,
+                    inactiveThumbColor: Colors.grey.shade400,
+                    inactiveTrackColor: Colors.grey.shade300,
+                  ),
+                ],
+              ),
             ),
           ),
         ],

--- a/lib/screens/settings_page.dart
+++ b/lib/screens/settings_page.dart
@@ -179,6 +179,8 @@ class SettingsPage extends ConsumerWidget {
                       notificationsNotifier.state = value;
                       await UserService.updateNotificationPreference(value);
 
+                      if (!context.mounted) return; // THE FIX: Check if the context is still valid before using it.
+
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(
                           content: Text(value


### PR DESCRIPTION
This PR implements a notification settings toggle under the Settings Page, allowing users to enable or disable push notifications. Key features included:

✨ Features Implemented:
✅ Notification toggle switch in SettingsPage
✅ Firestore sync: saves user's preference (notificationsEnabled) under their document in the users collection
✅ Riverpod state management using notification_settings_provider.dart
✅ Themed UI support: ensures toggle looks correct in both dark and light modes
✅ Toast feedback using ScaffoldMessenger when toggle is updated

🛠️ Files Modified:
lib/screens/settings_page.dart
lib/screens/home_page.dart
lib/services/user_service.dart
➕ lib/providers/notification_settings_provider.dart

📋 Next Steps:
Ensure push notifications respect the notificationsEnabled value (optional filter logic during FCM broadcast).
Polish the Notification UX based on final project feedback.