### PR TITLE
Implement Expiry Notifications and Notification Viewer Functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,11 @@ app.*.map.json
 /android/app/profile
 /android/app/release
 pubspec.lock
+ios/Podfile
+ios/Flutter/Debug.xcconfig
+ios/Flutter/Release.xcconfig
+.gitignore
+macos/Flutter/Flutter-Debug.xcconfig
+macos/Flutter/Flutter-Release.xcconfig
+macos/Podfile
+macos/Flutter/Flutter-Release.xcconfig

--- a/lib/models/notification_model.dart
+++ b/lib/models/notification_model.dart
@@ -6,6 +6,8 @@ class AppNotification {
   final String body;
   final DateTime createdAt;
   final bool read;
+  final String? documentId;  // NEW: for linking to a document
+  final String? type;        // NEW: e.g., "shared", "expiring"
 
   AppNotification({
     required this.id,
@@ -13,6 +15,8 @@ class AppNotification {
     required this.body,
     required this.createdAt,
     required this.read,
+    this.documentId,
+    this.type,
   });
 
   factory AppNotification.fromFirestore(String id, Map<String, dynamic> data) {
@@ -22,6 +26,8 @@ class AppNotification {
       body: data['body'] ?? '',
       createdAt: (data['createdAt'] as Timestamp).toDate(),
       read: data['read'] ?? false,
+      documentId: data['documentId'], // can be null
+      type: data['type'],             // can be null
     );
   }
 }

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -1,8 +1,10 @@
+import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/notification_model.dart';
 import 'auth_state_provider.dart';
 
+/// Stream provider for all notifications sorted by latest first
 final notificationsProvider = StreamProvider<List<AppNotification>>((ref) {
   final user = ref.watch(authStateProvider).currentUser;
   if (user == null) return const Stream.empty();
@@ -14,7 +16,24 @@ final notificationsProvider = StreamProvider<List<AppNotification>>((ref) {
       .orderBy('createdAt', descending: true)
       .snapshots();
 
-  return stream.map((snapshot) => snapshot.docs
-      .map((doc) => AppNotification.fromFirestore(doc.id, doc.data()))
-      .toList());
+  return stream.map(
+    (snapshot) => snapshot.docs
+        .map((doc) => AppNotification.fromFirestore(doc.id, doc.data()))
+        .toList(),
+  );
+});
+
+/// Stream provider for counting unread notifications
+final unreadNotificationsCountProvider = StreamProvider<int>((ref) {
+  final user = ref.watch(authStateProvider).currentUser;
+  if (user == null) return const Stream.empty();
+
+  final stream = FirebaseFirestore.instance
+      .collection('users')
+      .doc(user.uid)
+      .collection('notifications')
+      .where('read', isEqualTo: false)
+      .snapshots();
+
+  return stream.map((snapshot) => snapshot.docs.length);
 });

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -1,4 +1,3 @@
-import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import '../models/notification_model.dart';

--- a/lib/routing/app_router.dart
+++ b/lib/routing/app_router.dart
@@ -16,6 +16,8 @@ import '../providers/welcome_state_provider.dart';
 import '../screens/notification_page.dart';
 import '../screens/trusted_contact.dart';
 import '../screens/see_trusted_contacts_document.dart';
+import '../screens/shared_document_viewer_by_id.dart';
+import '../screens/view_document_page_by_id.dart';
 
 final appRouterProvider = Provider<GoRouter>((ref) {
   final authNotifier = ref.watch(authStateProvider);
@@ -79,6 +81,22 @@ final appRouterProvider = Provider<GoRouter>((ref) {
           final currentUserId =
               ref.read(authStateProvider).currentUser?.uid ?? '';
           return TrustedContact(currentUserId: currentUserId);
+        },
+      ),
+      GoRoute(
+        path: '/shared-document-view',
+        name: 'shared-document-view',
+        builder: (context, state) {
+          final docId = state.extra as String;
+          return SharedDocumentViewerPageById(documentId: docId);
+        },
+      ),
+      GoRoute(
+        path: '/view-document',
+        name: 'view-document',
+        builder: (context, state) {
+          final docId = state.extra as String;
+          return ViewDocumentPageById(documentId: docId);
         },
       ),
       GoRoute(

--- a/lib/screens/notification_page.dart
+++ b/lib/screens/notification_page.dart
@@ -57,6 +57,7 @@ class NotificationPage extends ConsumerWidget {
     ref.invalidate(notificationsProvider);
     ref.invalidate(unreadNotificationsCountProvider);
 
+    if (!context.mounted) return;
     ScaffoldMessenger.of(context).showSnackBar(
       const SnackBar(content: Text('All notifications cleared')),
     );
@@ -93,6 +94,7 @@ class NotificationPage extends ConsumerWidget {
               );
 
               if (confirm == true) {
+                if (!context.mounted) return;
                 await clearAllNotifications(context, ref);
               }
             },
@@ -130,6 +132,7 @@ class NotificationPage extends ConsumerWidget {
                 onDismissed: (_) async {
                   await deleteNotification(ref, notif.id);
 
+                  if (!context.mounted) return;
                   ScaffoldMessenger.of(context).showSnackBar(
                     SnackBar(
                       content: const Text('Notification deleted'),

--- a/lib/screens/notification_page.dart
+++ b/lib/screens/notification_page.dart
@@ -1,35 +1,104 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:go_router/go_router.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:cloud_firestore/cloud_firestore.dart';
 import '../providers/notification_provider.dart';
 import '../providers/auth_state_provider.dart';
 
 class NotificationPage extends ConsumerWidget {
   const NotificationPage({super.key});
 
+  Future<void> markAsRead(WidgetRef ref, String docId) async {
+    final user = ref.read(authStateProvider).currentUser;
+    if (user == null) return;
+
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('notifications')
+        .doc(docId)
+        .update({'read': true});
+
+    ref.invalidate(notificationsProvider);
+    ref.invalidate(unreadNotificationsCountProvider);
+  }
+
+  Future<void> deleteNotification(WidgetRef ref, String docId) async {
+    final user = ref.read(authStateProvider).currentUser;
+    if (user == null) return;
+
+    await FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('notifications')
+        .doc(docId)
+        .delete();
+
+    ref.invalidate(notificationsProvider);
+    ref.invalidate(unreadNotificationsCountProvider);
+  }
+
+  Future<void> clearAllNotifications(BuildContext context, WidgetRef ref) async {
+    final user = ref.read(authStateProvider).currentUser;
+    if (user == null) return;
+
+    final notifRef = FirebaseFirestore.instance
+        .collection('users')
+        .doc(user.uid)
+        .collection('notifications');
+
+    final batch = FirebaseFirestore.instance.batch();
+    final snapshot = await notifRef.get();
+    for (var doc in snapshot.docs) {
+      batch.delete(doc.reference);
+    }
+
+    await batch.commit();
+    ref.invalidate(notificationsProvider);
+    ref.invalidate(unreadNotificationsCountProvider);
+
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('All notifications cleared')),
+    );
+  }
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final notificationsAsync = ref.watch(notificationsProvider);
 
-    // Mark all as read when the page builds
-    WidgetsBinding.instance.addPostFrameCallback((_) async {
-      final user = ref.read(authStateProvider).currentUser;
-      if (user == null) return;
-
-      final snapshot = await FirebaseFirestore.instance
-          .collection('users')
-          .doc(user.uid)
-          .collection('notifications')
-          .where('read', isEqualTo: false)
-          .get();
-
-      for (var doc in snapshot.docs) {
-        doc.reference.update({'read': true});
-      }
-    });
-
     return Scaffold(
-      appBar: AppBar(title: const Text("Notifications")),
+      appBar: AppBar(
+        title: const Text("Notifications"),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.delete_forever),
+            tooltip: 'Clear All',
+            onPressed: () async {
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (ctx) => AlertDialog(
+                  title: const Text('Clear All Notifications?'),
+                  content: const Text('This action cannot be undone.'),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx, false),
+                      child: const Text('Cancel'),
+                    ),
+                    TextButton(
+                      onPressed: () => Navigator.pop(ctx, true),
+                      child: const Text('Clear All'),
+                    ),
+                  ],
+                ),
+              );
+
+              if (confirm == true) {
+                await clearAllNotifications(context, ref);
+              }
+            },
+          )
+        ],
+      ),
       body: notificationsAsync.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text("Error: $e")),
@@ -38,22 +107,82 @@ class NotificationPage extends ConsumerWidget {
             return const Center(child: Text("No notifications yet."));
           }
 
+          final sortedNotifs = [...notifications]
+            ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+
           return ListView.builder(
-            itemCount: notifications.length,
+            itemCount: sortedNotifs.length,
             itemBuilder: (context, index) {
-              final notif = notifications[index];
-              return ListTile(
-                leading: Icon(
-                  notif.read
-                      ? Icons.mark_email_read_outlined
-                      : Icons.notifications_active_outlined,
+              final notif = sortedNotifs[index];
+              final created = notif.createdAt;
+              final formattedTime =
+                  '${created.day}/${created.month} ${created.hour}:${created.minute.toString().padLeft(2, '0')}';
+
+              return Dismissible(
+                key: Key(notif.id),
+                direction: DismissDirection.endToStart,
+                background: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 20),
+                  alignment: Alignment.centerRight,
+                  color: Colors.red,
+                  child: const Icon(Icons.delete, color: Colors.white),
                 ),
-                title: Text(notif.title),
-                subtitle: Text(notif.body),
-                trailing: Text(
-                  '${notif.createdAt.day}/${notif.createdAt.month} '
-                  '${notif.createdAt.hour}:${notif.createdAt.minute.toString().padLeft(2, '0')}',
-                  style: Theme.of(context).textTheme.labelSmall,
+                onDismissed: (_) async {
+                  await deleteNotification(ref, notif.id);
+
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(
+                      content: const Text('Notification deleted'),
+                      duration: const Duration(seconds: 2),
+                    ),
+                  );
+                },
+                child: ListTile(
+                  leading: Icon(
+                    notif.read ? Icons.mark_email_read : Icons.notifications,
+                    color: notif.read ? Colors.grey : Colors.blue,
+                  ),
+                  title: Text(
+                    notif.title,
+                    style: TextStyle(
+                      fontWeight:
+                          notif.read ? FontWeight.normal : FontWeight.bold,
+                      color: notif.read ? Colors.black : Colors.blue.shade800,
+                    ),
+                  ),
+                  subtitle: Text(
+                    notif.body,
+                    style: TextStyle(
+                      fontWeight:
+                          notif.read ? FontWeight.normal : FontWeight.bold,
+                    ),
+                  ),
+                  trailing: Text(
+                    formattedTime,
+                    style: Theme.of(context).textTheme.labelSmall,
+                  ),
+                  onTap: () async {
+                    final user = ref.read(authStateProvider).currentUser;
+                    if (user == null) return;
+
+                    await markAsRead(ref, notif.id);
+
+                    if (notif.documentId != null && notif.type == 'shared') {
+                      if (context.mounted) {
+                        context.pushNamed(
+                          'shared-document-view',
+                          extra: notif.documentId,
+                        );
+                      }
+                    } else if (notif.documentId != null && notif.type == 'expiry') {
+                      if (context.mounted) {
+                        context.pushNamed(
+                          'view-document',
+                          extra: notif.documentId,
+                        );
+                      }
+                    }
+                  },
                 ),
               );
             },

--- a/lib/screens/shared_document_viewer_by_id.dart
+++ b/lib/screens/shared_document_viewer_by_id.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/document.dart';
+import 'shared_document_viewer_page.dart';
+
+class SharedDocumentViewerPageById extends StatefulWidget {
+  final String documentId;
+
+  const SharedDocumentViewerPageById({super.key, required this.documentId});
+
+  @override
+  State<SharedDocumentViewerPageById> createState() => _SharedDocumentViewerPageByIdState();
+}
+
+class _SharedDocumentViewerPageByIdState extends State<SharedDocumentViewerPageById> {
+  late Future<Document?> _documentFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    _documentFuture = _fetchDocument();
+  }
+
+  Future<Document?> _fetchDocument() async {
+    final docSnap = await FirebaseFirestore.instance
+        .collection('documents')
+        .doc(widget.documentId)
+        .get();
+
+    if (docSnap.exists) {
+      return Document.fromFirestore(docSnap);
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Document?>(
+      future: _documentFuture,
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Scaffold(
+            appBar: AppBar(title: const Text("Loading...")),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data == null) {
+          return Scaffold(
+            appBar: AppBar(title: const Text("Error")),
+            body: const Center(child: Text('Shared document not found or access denied.')),
+          );
+        }
+
+        final document = snapshot.data!;
+        return SharedDocumentViewerPage(document: document);
+      },
+    );
+  }
+}

--- a/lib/screens/shared_documents_page.dart
+++ b/lib/screens/shared_documents_page.dart
@@ -17,7 +17,10 @@ class SharedDocumentsPage extends ConsumerWidget {
     final user = authNotifier.currentUser;
 
     return Scaffold(
-      appBar: AppBar(title: const Text('Shared Documents')),
+      appBar: AppBar(
+        title: const Text('Shared Documents'),
+        leading: const BackButton(),
+        ),
       // Only show drawer if user is logged in
       drawer: user != null ? HomePageMenuBar() : null,
       body: sharedDocumentsAsyncValue.when(

--- a/lib/screens/view_document_page_by_id.dart
+++ b/lib/screens/view_document_page_by_id.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/document.dart';
+import 'view_document_page.dart';
+
+class ViewDocumentPageById extends StatelessWidget {
+  final String documentId;
+
+  const ViewDocumentPageById({super.key, required this.documentId});
+
+  Future<Document?> _fetchDocument() async {
+    final docSnap = await FirebaseFirestore.instance
+        .collection('documents')
+        .doc(documentId)
+        .get();
+
+    if (docSnap.exists) {
+      return Document.fromFirestore(docSnap);
+    }
+    return null;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Document?>(
+      future: _fetchDocument(),
+      builder: (context, snapshot) {
+        if (snapshot.connectionState == ConnectionState.waiting) {
+          return Scaffold(
+            appBar: AppBar(title: const Text("Loading Document")),
+            body: const Center(child: CircularProgressIndicator()),
+          );
+        }
+
+        if (!snapshot.hasData || snapshot.data == null) {
+          return Scaffold(
+            appBar: AppBar(title: const Text("Not Found")),
+            body: const Center(child: Text('Document not found or access denied.')),
+          );
+        }
+
+        return ViewDocumentPage(document: snapshot.data!);
+      },
+    );
+  }
+}

--- a/lib/widgets/homepage_menu_bar_widget.dart
+++ b/lib/widgets/homepage_menu_bar_widget.dart
@@ -95,7 +95,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context); // Close the drawer
-                context.go('/'); // Navigate to Home (root path)
+                context.push('/'); // Navigate to Home (root path)
               }
             },
           ),
@@ -112,7 +112,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context); // Close the drawer
-                context.go('/document-upload');
+                context.push('/document-upload');
               }
             },
           ),
@@ -163,7 +163,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context);
-                context.go('/shared-documents');
+                context.push('/shared-documents');
               }
             },
           ),
@@ -180,7 +180,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context);
-                context.go('/profile');
+                context.push('/profile');
               }
             },
           ),
@@ -197,7 +197,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context);
-                context.go('/settings');
+                context.push('/settings');
               }
             },
           ),
@@ -214,7 +214,7 @@ class HomePageMenuBar extends ConsumerWidget {
             onTap: () {
               if (context.mounted) {
                 Navigator.pop(context);
-                context.go('/chat');
+                context.push('/chat');
               }
             },
           ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -67,6 +67,7 @@ dependencies:
   image_picker: ^1.1.2
   shared_preferences: ^2.5.3
   flutter_pdfview: ^1.3.2
+  badges: ^3.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
📝 Pull Request Description:
This pull request introduces the following major features and improvements:

✅ Document Expiry Notifications:

Automatically checks documents for expiry (3 or 7 days remaining).
Saves expiry notifications to Firestore (with de-duplication logic).
Displays expiry alerts as local in-app notifications.
✅ Notification Center:

Notification list UI with badges for unread notifications.
Allows users to mark notifications as read upon tapping.
Supports swipe-to-delete and bulk clearing of notifications.
Proper navigation to the relevant document (expiry → ViewDocumentPage).
✅ Technical Improvements:

Clean separation of expiry vs shared notification types.
Correct navigation routing and app bar fixes for document viewer pages.
Improved local notification styling and Firebase logic.
🔧 Known Limitation: Shared document notifications are not yet functioning. This will be addressed in a separate PR.